### PR TITLE
setting: 간단한 시큐리티 설정 및 스웨거 설정, 환경파일 등록

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,77 @@
+name: EATAMAMA-BE Deploy To EC2
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  Server-Deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Github Repository 파일 불러오기
+        uses: actions/checkout@v4
+
+      - name: JDK 17버전 설치
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+
+#      - name: application-dev-oauth.yml 파일 생성하기
+#        run: |
+#          echo "${{ secrets.APPLICATION_DEV_OAUTH_YML }}" | base64 --decode > ./src/main/resources/application-dev-oauth.yml
+
+      - name: application-dev.yml 파일 생성하기
+        run: |
+          echo "${{ secrets.APPLICATION_DEV_YML }}" | base64 --decode > ./src/main/resources/application-dev.yml
+
+      - name: 빌드 권한 부여
+        run: chmod +x ./gradlew
+
+      - name: 테스트 및 빌드하기
+        run: ./gradlew clean build -x test
+
+      - name: AWS Resource에 접근할 수 있게 AWS credentials 설정
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: ap-northeast-2
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+      - name: ECR에 로그인하기
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Docker 이미지 생성
+        run: docker build -t busan .
+
+      - name: Docker 이미지에 Tag 붙이기
+        run: docker tag busan ${{ steps.login-ecr.outputs.registry }}/busan:latest
+
+      - name: ECR에 Docker 이미지 Push하기
+        run: docker push ${{ steps.login-ecr.outputs.registry }}/busan:latest
+
+      - name: SSH로 bastion host 접속 및 실제 서버에 배포하기
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ secrets.BASTION_HOST }}
+          username: ${{ secrets.BASTION_USERNAME }}
+          key: ${{ secrets.SERVER_PRIVATE_KEY }}
+          script_stop: true
+          script: |
+            ssh -o StrictHostKeyChecking=no \
+                -i ~/.ssh/eatamama-server.pem \
+                ubuntu@${{ secrets.PRIVATE_EC2_INTERNAL_IP }} << 'EOF'
+            
+              aws ecr get-login-password --region ap-northeast-2 \
+                | docker login --username AWS --password-stdin ${{ steps.login-ecr.outputs.registry }}
+            
+              docker stop busan || true
+              docker rm busan || true
+              docker pull ${{ steps.login-ecr.outputs.registry }}/busan:latest
+              docker run -d --name busan --restart=unless-stopped \
+                -e SPRING_PROFILES_ACTIVE=dev \
+                -p 8080:8080 \
+                ${{ steps.login-ecr.outputs.registry }}/busan:latest
+            EOF

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM openjdk:17-jdk
+
+COPY ./build/libs/*SNAPSHOT.jar project.jar
+
+ENTRYPOINT ["java", "-jar", "/project.jar"]

--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,12 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/eata/eatamamabe/config/SwaggerConfig.java
+++ b/src/main/java/com/eata/eatamamabe/config/SwaggerConfig.java
@@ -1,0 +1,128 @@
+package com.eata.eatamamabe.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.examples.Example;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.media.*;
+import io.swagger.v3.oas.models.responses.ApiResponse;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
+import org.springdoc.core.customizers.OpenApiCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI customOpenAPI() {
+
+        String socialLoginGuide = """
+                        ## 📌 소셜 로그인 테스트 방법(아직 미구현)
+                        Swagger에서 직접 실행(`Try it out`)은 OAuth2 리다이렉트 흐름 특성상 동작하지 않습니다.
+                        대신 **브라우저 주소창**에서 아래 URL로 이동하세요:
+                        
+                        - 로컬 Kakao 로그인: [http://localhost:8080/oauth2/authorization/kakao](http://localhost:8080/oauth2/authorization/kakao)
+                        - 배포 Kakao 로그인: [http://43.203.72.175/oauth2/authorization/kakao](http://43.203.72.175/oauth2/authorization/kakao)
+                        
+                         ## 📌 예외 코드 처리(아직 미구현)
+                        각 api를 열어보면 Responses Code마다 예시가 하나씩 들어있습니다
+                        
+                        ## 📌 스웨거 테스트시 유의점
+                        바로 밑에 보이는 Servers에서 로컬환경이면 로컬주소를 선택해서, 배포환경이면 배포주소를 선택하고 테스트해주세요.
+                        """;
+
+        // Bearer(JWT) 스키마
+        SecurityScheme bearerScheme = new SecurityScheme()
+                .type(SecurityScheme.Type.HTTP)
+                .scheme("bearer")
+                .bearerFormat("JWT")
+                .in(SecurityScheme.In.HEADER)
+                .name(org.springframework.http.HttpHeaders.AUTHORIZATION)
+                .description("입력창에는 'Bearer' 없이 **AccessToken 문자열만** 넣으세요.");
+
+        return new OpenAPI()
+                .info(new Info()
+                        .title("Eatamama API")
+                        .version("v1.0")
+                        .description(socialLoginGuide))
+                .servers(List.of(
+                        new Server().url("http://localhost:8080").description("Local Development Server (HTTP)"),
+                        new Server().url("http://43.203.72.175").description("배포 Development Server (HTTP)")
+                ))
+                .components(new Components()
+                        .addSecuritySchemes("bearerAuth", bearerScheme)
+                )
+                // 전역으로 Bearer 필요하게(permitAll 엔드포인트는 무시됨)
+                .addSecurityItem(new SecurityRequirement().addList("bearerAuth"));
+    }
+
+    /**
+     * 공통 스키마 존재 보장 + 전 API 공통 에러 응답 일괄 추가
+     * (그룹 문서/빈 초기화 순서 이슈 대응 + 상태코드별 예시 부착)
+     */
+    @Bean
+    public OpenApiCustomizer globalErrorResponses() {
+        return openApi -> {
+            // --- 스키마 존재 보장 ---
+            if (openApi.getComponents() == null) {
+                openApi.setComponents(new Components());
+            }
+            var components = openApi.getComponents();
+            if (components.getSchemas() == null) {
+                components.setSchemas(new LinkedHashMap<>());
+            }
+
+            // --- 공통 에러 응답 부착 (상태코드별 예시) ---
+            if (openApi.getPaths() == null) return;
+
+            openApi.getPaths().values().forEach(pathItem ->
+                    pathItem.readOperations().forEach(op -> {
+                        op.getResponses().addApiResponse("400",
+                                errorResponse("잘못된 요청(Validation/Binding)", "REQ.VALIDATION", "입력값을 확인해주세요."));
+                        op.getResponses().addApiResponse("401",
+                                errorResponse("인증 필요", "AUTH.UNAUTHORIZED", "로그인이 필요합니다."));
+                        op.getResponses().addApiResponse("403",
+                                errorResponse("권한 없음", "AUTH.FORBIDDEN", "접근 권한이 없습니다."));
+                        op.getResponses().addApiResponse("404",
+                                errorResponse("리소스 없음", "DATA.NOT_FOUND", "요청한 리소스를 찾을 수 없습니다."));
+                        op.getResponses().addApiResponse("409",
+                                errorResponse("중복/제약 위반", "DATA.DUPLICATE", "이미 존재하는 데이터입니다."));
+                        op.getResponses().addApiResponse("413",
+                                errorResponse("업로드 용량 초과", "UPLOAD.TOO_LARGE", "파일 용량 제한을 초과했습니다."));
+                        op.getResponses().addApiResponse("500",
+                                errorResponse("백엔드 서버 내부 오류", "SYS.INTERNAL", "서버 오류가 발생했습니다. 잠시 후 다시 시도해주세요."));
+                    })
+            );
+        };
+    }
+
+    // --- util: 상태코드/설명/에러코드/메시지를 받아 예시 포함 ApiResponse 생성 ---
+    private ApiResponse errorResponse(String description, String code, String message) {
+        boolean is500 = "SYS.INTERNAL".equals(code); // 또는 description/코드로 판별
+        Map<String, Object> exampleMap = new LinkedHashMap<>();
+        exampleMap.put("status", is500 ? "ERROR" : "FAIL");  // 4xx=FAIL, 5xx=ERROR
+        exampleMap.put("serverDateTime", "2025-08-09T12:34:56.789");
+        exampleMap.put("errorCode", code);
+        exampleMap.put("errorMessage", message);
+        exampleMap.put("data", null);
+
+        Example example = new Example()
+                .summary("예시")
+                .value(exampleMap);
+
+        MediaType mediaType = new MediaType()
+                .schema(new Schema<>().$ref("#/components/schemas/Response_Error"))
+                .addExamples("default", example);
+
+        Content content = new Content().addMediaType("application/json", mediaType);
+
+        return new ApiResponse().description(description).content(content);
+    }
+}

--- a/src/main/java/com/eata/eatamamabe/config/security/SecurityConfig.java
+++ b/src/main/java/com/eata/eatamamabe/config/security/SecurityConfig.java
@@ -1,0 +1,64 @@
+package com.eata.eatamamabe.config.security;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.List;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf((auth) -> auth.disable())
+                .formLogin((auth) -> auth.disable())
+                .cors(Customizer.withDefaults())
+                .httpBasic((auth) -> auth.disable())
+                .sessionManagement((session) -> session
+                        .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .headers(headers -> headers
+                        .frameOptions(HeadersConfigurer.FrameOptionsConfig::sameOrigin)
+                )
+                //경로별 인가 작업
+                .authorizeHttpRequests((auth) -> auth
+                        .requestMatchers("/swagger-ui.html",
+                                "/swagger-ui/**",
+                                "/api-docs/**",
+                                "/v3/api-docs/**",
+                                "/h2-console/**").permitAll()
+                        .requestMatchers("/api/**").permitAll()
+                        .anyRequest().authenticated());
+        return http.build();
+    }
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration config = new CorsConfiguration();
+        config.setAllowedOrigins(List.of(
+                "http://localhost:5173",
+                "http://localhost:8080"
+        ));
+        config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+        config.setAllowedHeaders(List.of("*"));
+        config.setAllowCredentials(true);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", config);
+
+        return source;
+    }
+
+}

--- a/src/main/resources/application-swagger.yml
+++ b/src/main/resources/application-swagger.yml
@@ -1,0 +1,13 @@
+springdoc:
+  api-docs:
+    path: /v3/api-docs
+  swagger-ui:
+    path: /swagger-ui.html
+    config-url: /v3/api-docs/swagger-config
+    url: /v3/api-docs
+    operationsSorter: method
+    tagsSorter: alpha
+    with-credentials: true
+  model-and-view-allowed: true
+  override-with-generic-response: false
+  show-actuator: true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,1 +1,4 @@
-spring.application.name=EataMamaBE
+spring:
+  config:
+    import: optional:classpath:application-${spring.profiles.active}.yml
+spring.profiles.active: dev


### PR DESCRIPTION
# feat: AWS 인프라 셋업 + Spring Security/CORS 기본설정 + Swagger 문서 템플릿 + CI 배포 파이프라인

## 관련이슈
#1 

## 1) 요약

* **AWS VPC**(Public/Private Subnet) 구성 및 **Bastion Host + Nginx** 설정 완료
* **Spring Security** 최소 보안 구성(State­less, CORS 허용, Swagger/H2 permitAll)
* **Swagger(OpenAPI)** 전역 보안 스키마/서버 프리셋/공통 에러 응답 예시 추가
* **GitHub Actions** `deploy.yml` 기반 **ECR 푸시 → Bastion 경유 배포** 파이프라인 작성

---

## 2) 주요 변경사항

### 2.1 인프라(AWS)

* VPC 서브넷 분리: **Public Subnet(IGW 연결, Bastion/Nginx)**, **Private Subnet(EC2 App)**
* Bastion Host에서 **Nginx 리버스 프록시** 구성 (HTTP Dev)
* Bastion → Private EC2로 SSH 터널 배포 경로 확보

> 운영 전환 시: ALB/HTTPS(ACM), 보안그룹 최소화, NAT 비용 검토 예정

---

### 2.2 Spring Security (`SecurityConfig`)

* 세션 `STATELESS`, CSRF/FormLogin/Basic 비활성화
* Swagger/H2 콘솔 경로 **permitAll**
* 임시로 `/api/**` **permitAll** (MVP 구간, 추후 역할/토큰 인가로 강화 예정)
* **CORS 허용**: `http://localhost:5173`, `http://localhost:8080`

  * Methods: `GET, POST, PUT, DELETE, OPTIONS`
  * Headers: `*`
  * Credentials: `true`

```java
// 핵심 포인트만 발췌
http
  .csrf(csrf -> csrf.disable())
  .formLogin(form -> form.disable())
  .cors(Customizer.withDefaults())
  .httpBasic(b -> b.disable())
  .sessionManagement(s -> s.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
  .headers(h -> h.frameOptions(HeadersConfigurer.FrameOptionsConfig::sameOrigin))
  .authorizeHttpRequests(auth -> auth
      .requestMatchers("/swagger-ui.html","/swagger-ui/**","/api-docs/**","/v3/api-docs/**","/h2-console/**").permitAll()
      .requestMatchers("/api/**").permitAll()
      .anyRequest().authenticated()
  );
```

> ⚠️ 프런트 주소/도메인 확정 시 `corsConfigurationSource()`의 **AllowedOrigins** 에 반드시 추가 필요

---

### 2.3 Swagger (`SwaggerConfig`)

* **Servers** 미리 지정(로컬/배포 Dev)
* **BearerAuth 스키마** 전역 등록(설명은 AccessToken 문자열만 입력하도록 안내)
* **공통 에러 응답(4xx/5xx) 예시** 전 API 자동 부착
* OAuth2 로그인 가이드(미구현 안내) 문서 상단 설명에 포함

```java
new OpenAPI()
  .info(new Info().title("Eatamama API").version("v1.0").description(socialLoginGuide))
  .servers(List.of(
      new Server().url("http://localhost:8080").description("Local Development Server (HTTP)"),
      new Server().url("http://43.203.72.175").description("배포 Development Server (HTTP)")
  ))
  .components(new Components().addSecuritySchemes("bearerAuth", bearerScheme))
  .addSecurityItem(new SecurityRequirement().addList("bearerAuth"));
```

---

### 2.4 CI/CD (`deploy.yml`)

* GitHub Actions에서:

  1. **ECR 로그인 & 이미지 푸시**
  2. **Bastion에 SSH 접속** 후 Private EC2에 **Docker 컨테이너 재기동**
* 실패 내성: 컨테이너 없으면 `stop/rm` 무시하도록 처리

> 참고: 배포 스크립트 내부에서 `SPRING_PROFILES_ACTIVE=dev` 로 실행 (필요 시 `prod` 분기)

---

## 3) 테스트 방법

### 3.1 로컬

1. 백엔드 실행: `./gradlew bootRun` (또는 Docker)
2. Swagger 접속:

   * `http://localhost:8080/swagger-ui/index.html`
3. H2 콘솔(옵션):

   * `http://localhost:8080/h2-console`

### 3.2 Dev 서버(HTTP)

* Swagger: `http://43.203.72.175/swagger-ui/index.html`
* Swagger 좌측 상단 **Servers**에서 환경(로컬/배포) 선택 후 테스트
* CORS 에러 시: **요청 Origin**이 `allowedOrigins` 에 포함되어 있는지 확인

---

## 4) 보안/운영 고려사항 (후속 이슈로 분리 예정)

* `/api/**` 현재 `permitAll` → **JWT/OAuth2 인가 체계** 적용 후 롤백
* **HTTPS** 전환(ACM, ALB/NLB) 및 **보안그룹 최소화**
* Swagger의 Bearer 스키마 사용 시, **토큰 표기 규칙(“Bearer” 접두사 미사용)** 문서에 재명시
* CORS Origin 화이트리스트 **프로퍼티화**(환경별 분리)
* Bastion에 저장하는 키 권한: `chmod 600 ~/.ssh/<key>.pem`

---

## 5) 변경 파일(요약)

* `config/security/SecurityConfig.java` : 시큐리티/코르스/인가
* `config/SwaggerConfig.java` : OpenAPI/에러응답/서버 프리셋
* `.github/workflows/deploy.yml` : ECR 빌드·푸시 및 Bastion 경유 배포
* (인프라 스크립트/도큐먼트는 별도 리포/Notion 정리 예정)

---

## 6) 스크린샷/증빙 (선택)

* [ ] Swagger UI(로컬/배포) 캡처
* [ ] 배포 로그 캡처(GitHub Actions 성공 화면)
* [ ] Nginx 프록시 정상 라우팅 확인 캡처

---

## 7) 체크리스트

* [x] 로컬 Swagger 접근 OK
* [x] Dev Swagger 접근 OK
* [x] CORS Preflight(OPTIONS) 응답 OK
* [x] GitHub Actions 배포 성공
* [x] Bastion → Private EC2 SSH OK (`chmod 600` 확인)

---

## 8) 기타

* 이번 PR은 **MVP 배포 안정화** 목적의 기본선 구축입니다.
* 보안 강화를 위해 인증/인가 파트는 다음 PR에서 단계적으로 적용하겠습니다.
