### PR TITLE
feature: 식단 가져오기 api

### DIFF
--- a/src/main/java/com/eata/eatamamabe/controller/MealController.java
+++ b/src/main/java/com/eata/eatamamabe/controller/MealController.java
@@ -2,10 +2,12 @@ package com.eata.eatamamabe.controller;
 
 import com.eata.eatamamabe.config.security.CustomUserDetails;
 import com.eata.eatamamabe.dto.common.Response;
+import com.eata.eatamamabe.dto.meal.DayLogDetailResponseDTO;
 import com.eata.eatamamabe.dto.meal.MealCreateRequestDTO;
 import com.eata.eatamamabe.dto.meal.MealCreateResponseDTO;
 import com.eata.eatamamabe.service.MealService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -16,7 +18,7 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 public class MealController {
 
-    private final MealService MealService;
+    private final MealService mealService;
 
     @Operation(summary = "식단 등록하기",
             description = """
@@ -30,6 +32,18 @@ public class MealController {
             @RequestBody MealCreateRequestDTO request,
             @AuthenticationPrincipal CustomUserDetails principal
     ) {
-        return ResponseEntity.ok(Response.success(MealService.createMeal(principal.getId(), request)));
+        return ResponseEntity.ok(Response.success(mealService.createMeal(principal.getId(), request)));
+    }
+
+    @Operation(summary = "식단 가져오기",
+            description = "logDate(yyyy-MM-dd) 기준 하루 식단 전체를 반환합니다.")
+    @GetMapping
+    public ResponseEntity<Response<DayLogDetailResponseDTO>> getMealsByDate(
+            @Parameter(description = "하루 기준 날짜(yyyy-MM-dd)", example = "2025-09-03", required = true)
+            @RequestParam String logDate,
+            @AuthenticationPrincipal(expression = "id") Long userId
+    ) {
+        DayLogDetailResponseDTO data = mealService.getMealsByDate(userId, logDate);
+        return ResponseEntity.ok(Response.success(data));
     }
 }

--- a/src/main/java/com/eata/eatamamabe/dto/meal/DayLogDetailResponseDTO.java
+++ b/src/main/java/com/eata/eatamamabe/dto/meal/DayLogDetailResponseDTO.java
@@ -1,0 +1,15 @@
+package com.eata.eatamamabe.dto.meal;
+
+import lombok.*;
+import java.util.List;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class DayLogDetailResponseDTO {
+    private Long dayLogId;
+    private String logDate;
+    private String dailyAdvice; // null 가능
+    private List<MealSummaryDTO> meals;
+}

--- a/src/main/java/com/eata/eatamamabe/dto/meal/IntakeSimpleDTO.java
+++ b/src/main/java/com/eata/eatamamabe/dto/meal/IntakeSimpleDTO.java
@@ -1,0 +1,11 @@
+package com.eata.eatamamabe.dto.meal;
+
+import lombok.*;
+
+@Getter @Setter
+@AllArgsConstructor @NoArgsConstructor
+public class IntakeSimpleDTO {
+    private Long intakeId;
+    private String intakeName;
+    private Long intakeKcal;
+}

--- a/src/main/java/com/eata/eatamamabe/dto/meal/MealSummaryDTO.java
+++ b/src/main/java/com/eata/eatamamabe/dto/meal/MealSummaryDTO.java
@@ -1,0 +1,15 @@
+package com.eata.eatamamabe.dto.meal;
+
+import com.eata.eatamamabe.entity.enums.MealType;
+import lombok.*;
+import java.util.List;
+
+@Getter @Setter
+@AllArgsConstructor @NoArgsConstructor
+public class MealSummaryDTO {
+    private Long mealId;
+    private MealType mealType;
+    private String mealName;
+    private String mealAdvice;
+    private List<IntakeSimpleDTO> intakes;
+}

--- a/src/main/java/com/eata/eatamamabe/repository/MealRepository.java
+++ b/src/main/java/com/eata/eatamamabe/repository/MealRepository.java
@@ -2,6 +2,18 @@ package com.eata.eatamamabe.repository;
 
 import com.eata.eatamamabe.entity.Meal;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface MealRepository extends JpaRepository<Meal, Long> {
+    @Query("""
+        select distinct m
+        from Meal m
+        left join fetch m.intakes i
+        where m.dayLog.dayLogId = :dayLogId
+        order by m.mealTime asc, m.mealId asc
+    """)
+    List<Meal> findAllByDayLogIdWithIntakes(@Param("dayLogId") Long dayLogId);
 }


### PR DESCRIPTION
# feat(meal): logDate 기준 **식단 조회 API** 추가

## 요약

* 사용자 `userId`와 `logDate(yyyy-MM-dd)`로 하루치 **식단 상세**를 반환
* `DayLog`(일간 로그) + 하위 `Meal` + `Intake`를 **단일 조회**로 묶어 응답
* `Meal ↔ Intake`는 **fetch join**으로 N+1 방지

## 주요 변경 사항

* **Controller**

  * `GET /api/meals?logDate=2025-09-03` (`MealController#getMealsByDate`)
* **Service**

  * `MealService#getMealsByDate(Long userId, String logDate)`
* **Repository**

  * `MealRepository#findAllByDayLogIdWithIntakes(Long dayLogId)` — `intakes` fetch join + 정렬
* **DTO**

  * `DayLogDetailResponseDTO` (dayLog 헤더 + meals)
  * `MealSummaryDTO` (meal 헤더 + intakes)
  * `IntakeSimpleDTO` (간단 섭취 항목)

> **DB 스키마 변경 없음**

## API 스펙

* **Method / Path**: `GET /api/meals`
* **Query**: `logDate` (예: `2025-09-03`) **required**
* **Auth**: 로그인 필요 (`@AuthenticationPrincipal(expression = "id")`에서 `userId` 획득)
* **Response 예시**

```json
{
  "data": {
    "dayLogId": 12,
    "logDate": "2025-09-03",
    "dailyAdvice": "단백질은 적정, 채소가 부족합니다.",
    "meals": [
      {
        "mealId": 33,
        "mealType": "BREAKFAST",
        "mealName": "샐러드&커피",
        "mealAdvice": "가볍고 좋아요.",
        "intakes": [
          { "intakeId": 101, "intakeName": "토스트", "intakeKcal": 320 },
          { "intakeId": 102, "intakeName": "우유", "intakeKcal": 110 }
        ]
      },
      {
        "mealId": 34,
        "mealType": "LUNCH",
        "mealName": "도시락",
        "mealAdvice": "나트륨이 조금 높아요.",
        "intakes": [
          { "intakeId": 103, "intakeName": "김밥", "intakeKcal": 243 }
        ]
      }
    ]
  },
  "status": "SUCCESS",
  "serverDateTime": "2025-09-03T14:10:00",
  "errorCode": null,
  "errorMessage": null
}
```

## 동작/로직

1. `userId`로 사용자 존재 여부 검증
2. `(user, logDate)`로 `DayLog` 조회

   * 없으면 `CustomException` 발생
3. `MealRepository#findAllByDayLogIdWithIntakes`로 `Meal + Intake` 일괄 로드

   * `left join fetch m.intakes`로 N+1 방지
   * `order by m.mealTime asc, m.mealId asc`
4. DTO로 매핑 후 공통 래퍼 `Response.success(...)`로 반환

## 테스트 방법 (스웨거/포스트맨)

1. 로그인 후 **`GET /api/meals?logDate=2025-09-03`** 호출
2. 응답의 `dayLogId`, `meals[*].intakes[*]` 확인
3. 대량 데이터에서도 쿼리 수 증가 없는지(N+1 없음) 로그/프로파일러로 확인

## 성능/안전

* **쿼리 수 최소화**: DayLog 1회 + Meals(fetch join) 1회
* **정렬 보장**: `mealTime asc, mealId asc`
* **호환성**: 생성 API와 동일한 엔티티/DTO 구성 사용, DB 변경 없음

## TODO (후속)

* `DayLog` 미존재 시 **빈 결과 반환** vs **예외** 정책 확정
* `dailyAdvice`가 없을 때 클라이언트 문구 처리(옵셔널)
* 날짜 파라미터를 `yyyy-MM-dd` 포맷 검증(Bean Validation 커스텀 또는 컨버터)

---
